### PR TITLE
Error handling and other robustness related changes

### DIFF
--- a/lib/generators/templates/rails_opentracer_initializer.rb
+++ b/lib/generators/templates/rails_opentracer_initializer.rb
@@ -1,7 +1,7 @@
-require 'OpenTracing'
-require 'Zipkin'
-require 'Rails'
+require 'opentracing'
+require 'zipkin'
 
-OpenTracing.global_tracer = Zipkin::Tracer.build(url: ENV['ZIPKIN_SERVICE_URL'], service_name: Rails.application.class.parent_name)
-
-ActiveRecord::RailsOpentracer.instrument(tracer: OpenTracing.global_tracer, active_span: -> { $active_span })
+if ENV.key?('ZIPKIN_SERVICE_URL')
+  OpenTracing.global_tracer = Zipkin::Tracer.build(url: ENV['ZIPKIN_SERVICE_URL'], service_name: Rails.application.class.parent_name)
+  ActiveRecord::RailsOpentracer.instrument(tracer: OpenTracing.global_tracer, active_span: -> { $active_span })
+end

--- a/lib/generators/templates/tracer.rb
+++ b/lib/generators/templates/tracer.rb
@@ -6,26 +6,36 @@ class Tracer
   end
 
   def call(env)
-    extracted_ctx = OpenTracing.extract(OpenTracing::FORMAT_RACK, env)
-    span_name = get_span_name(env['REQUEST_PATH'])
-
-    span =
-      if extracted_ctx.nil?
-        OpenTracing.start_span(span_name)
-      else
-        OpenTracing.start_span(span_name, child_of: extracted_ctx)
-      end
-    $active_span = span # yuck
+    span = nil
+    begin
+      extracted_ctx = OpenTracing.extract(OpenTracing::FORMAT_RACK, env)
+      span_name = env['REQUEST_PATH']
+      span =
+        if extracted_ctx.nil?
+          OpenTracing.start_span(span_name)
+        else
+          OpenTracing.start_span(span_name, child_of: extracted_ctx)
+        end
+      $active_span = span # yuck
+    rescue StandardError => e
+      Rails.logger.error "TRACER_ERROR: #{error_message(e)}"
+      return @app.call(env)
+    end
 
     status, headers, response = @app.call(env)
-    carrier = {}
-    OpenTracing.inject(span.context, OpenTracing::FORMAT_RACK, carrier)
-    span.finish
 
-    [status, headers , response]
+    begin
+      carrier = {}
+      OpenTracing.inject(span.context, OpenTracing::FORMAT_RACK, carrier)
+      span.finish
+      [status, headers , response]
+    rescue StandardError => e
+      Rails.logger.error "TRACER_ERROR: #{error_message(e)}"
+      [status, headers, response]
+    end
   end
 
-  def get_span_name(request_path)
-    Rails.application.routes.recognize_path(request_path).values.map { |i| i.to_s}.join(", ")
+  def error_message(e)
+    "#{e}\n#{e.backtrace[0, 10].join("\n\t")}"
   end
 end

--- a/lib/rails_opentracer/version.rb
+++ b/lib/rails_opentracer/version.rb
@@ -1,3 +1,3 @@
 module RailsOpentracer
-  VERSION = "0.1.15"
+  VERSION = "0.1.16"
 end


### PR DESCRIPTION
To make the tracer more robust any errors raised during the tracing
process will be rescued and logged.

Note this excludes errors originating in the application code.
The initializer has also been updated only attemp connection to
Zipkin if the URL for the server has been configured.