### PR TITLE
Making service URL configurable for dev and test

### DIFF
--- a/lib/rails_opentracer/version.rb
+++ b/lib/rails_opentracer/version.rb
@@ -1,3 +1,3 @@
 module RailsOpentracer
-  VERSION = '0.1.39'.freeze
+  VERSION = '0.1.40'.freeze
 end

--- a/lib/rails_opentracer/zipkin_config.rb
+++ b/lib/rails_opentracer/zipkin_config.rb
@@ -9,11 +9,7 @@ module RailsOpentracer
     end
 
     def self.zipkin_url
-      if Rails.env.test? || Rails.env.development?
-        'http://localhost:9411'
-      else
-        ENV['ZIPKIN_SERVICE_URL']
-      end
+      ENV['ZIPKIN_SERVICE_URL']
     end
   end
 end


### PR DESCRIPTION
The ZIPKIN_SERVICE_URL environment variable was hardcoded to localhost
for dev and test environments.

This causes issues when for instance running your application in a container
as localhost will resolve to the container in which the application is running,
which in most cases won't actually be where the zipkin service is running.